### PR TITLE
Changed abbreviation in parameter list

### DIFF
--- a/c/transform.h
+++ b/c/transform.h
@@ -2,8 +2,8 @@
 #define TRANSFORM_HEADER
 
 void wgs2gcj(double wgsLat, double wgsLng, double *gcjLat, double *gcjLng);
-void gcj2wgs(double gcjLat, double gcjLng, double *wgsLat, double *wgsLnt);
-void gcj2wgs_exact(double gcjLat, double gcjLng, double *wgsLat, double *wgsLnt);
+void gcj2wgs(double gcjLat, double gcjLng, double *wgsLat, double *wgsLng);
+void gcj2wgs_exact(double gcjLat, double gcjLng, double *wgsLat, double *wgsLng);
 double distance(double latA, double lngA, double latB, double lngB);
 
 #endif


### PR DESCRIPTION
Changed the "longitude" parameter abbreviation in gcj2wgs() & gcj2wgs_exact() function declaration, from Lnt to Lng, to make the naming convention more unified.

Longitude -> Lng
Latitude -> Lat