### PR TITLE
Fix typo: WSGPointer -> WGSPointer

### DIFF
--- a/java/src/com/lbt05/EvilTransform/GCJPointer.java
+++ b/java/src/com/lbt05/EvilTransform/GCJPointer.java
@@ -10,31 +10,31 @@ public class GCJPointer extends GeoPointer {
     this.longitude = longitude;
   }
 
-  public WSGPointer toWSGPointer() {
+  public WGSPointer toWGSPointer() {
     if (TransformUtil.outOfChina(this.latitude, this.longitude)) {
-      return new WSGPointer(this.latitude, this.longitude);
+      return new WGSPointer(this.latitude, this.longitude);
     }
     double[] delta = TransformUtil.delta(this.latitude, this.longitude);
-    return new WSGPointer(this.latitude - delta[0], this.longitude - delta[1]);
+    return new WGSPointer(this.latitude - delta[0], this.longitude - delta[1]);
   }
 
-  public WSGPointer toExactWSGPointer() {
+  public WGSPointer toExactWGSPointer() {
     final double initDelta = 0.01;
     final double threshold = 0.000001;
     double dLat = initDelta, dLng = initDelta;
     double mLat = this.latitude - dLat, mLng = this.longitude - dLng;
     double pLat = this.latitude + dLat, pLng = this.longitude + dLng;
     double wgsLat, wgsLng;
-    WSGPointer currentWSGPointer = null;
+    WGSPointer currentWGSPointer = null;
     for (int i = 0; i < 30; i++) {
       wgsLat = (mLat + pLat) / 2;
       wgsLng = (mLng + pLng) / 2;
-      currentWSGPointer = new WSGPointer(wgsLat, wgsLng);
-      GCJPointer tmp = currentWSGPointer.toGCJPointer();
+      currentWGSPointer = new WGSPointer(wgsLat, wgsLng);
+      GCJPointer tmp = currentWGSPointer.toGCJPointer();
       dLat = tmp.getLatitude() - this.getLatitude();
       dLng = tmp.getLongitude() - this.getLongitude();
       if ((Math.abs(dLat) < threshold) && (Math.abs(dLng) < threshold)) {
-        return currentWSGPointer;
+        return currentWGSPointer;
       } else {
         System.out.println(dLat + ":" + dLng);
       }
@@ -49,6 +49,6 @@ public class GCJPointer extends GeoPointer {
         mLng = wgsLng;
       }
     }
-    return currentWSGPointer;
+    return currentWGSPointer;
   }
 }

--- a/java/src/com/lbt05/EvilTransform/WGSPointer.java
+++ b/java/src/com/lbt05/EvilTransform/WGSPointer.java
@@ -1,10 +1,10 @@
 package com.lbt05.EvilTransform;
 
-public class WSGPointer extends GeoPointer {
+public class WGSPointer extends GeoPointer {
 
-  public WSGPointer() {}
+  public WGSPointer() {}
 
-  public WSGPointer(double latitude, double longitude) {
+  public WGSPointer(double latitude, double longitude) {
     this.latitude = latitude;
     this.longitude = longitude;
   }

--- a/java/src/com/lbt05/EvilTransform/test/GeoTest.java
+++ b/java/src/com/lbt05/EvilTransform/test/GeoTest.java
@@ -5,32 +5,32 @@ import static org.junit.Assert.*;
 import org.junit.Test;
 
 import com.lbt05.EvilTransform.GCJPointer;
-import com.lbt05.EvilTransform.WSGPointer;
+import com.lbt05.EvilTransform.WGSPointer;
 
 public class GeoTest {
-  WSGPointer shanghaiWSGPointer = new WSGPointer(31.1774276, 121.5272106);
+  WGSPointer shanghaiWGSPointer = new WGSPointer(31.1774276, 121.5272106);
   GCJPointer shanghaiGCJPointer = new GCJPointer(31.17530398364597, 121.531541859215);
-  WSGPointer shenzhenWSGPointer = new WSGPointer(22.543847, 113.912316);
+  WGSPointer shenzhenWGSPointer = new WGSPointer(22.543847, 113.912316);
   GCJPointer shenzhenGCJPointer = new GCJPointer(22.540796131694766, 113.9171764808363);
-  WSGPointer beijingWSGPointer = new WSGPointer(39.911954, 116.377817);
+  WGSPointer beijingWGSPointer = new WGSPointer(39.911954, 116.377817);
   GCJPointer beijingGCJPointer = new GCJPointer(39.91334545536069, 116.38404722455657);
 
   @Test
-  public void testWSG2GCJ() {
-    assertEquals(shanghaiGCJPointer, shanghaiWSGPointer.toGCJPointer());
-    assertEquals(shenzhenGCJPointer, shenzhenWSGPointer.toGCJPointer());
-    assertEquals(beijingGCJPointer, beijingWSGPointer.toGCJPointer());
+  public void testWGS2GCJ() {
+    assertEquals(shanghaiGCJPointer, shanghaiWGSPointer.toGCJPointer());
+    assertEquals(shenzhenGCJPointer, shenzhenWGSPointer.toGCJPointer());
+    assertEquals(beijingGCJPointer, beijingWGSPointer.toGCJPointer());
   }
 
-  public void testGCJ2WSG() {
-    assertTrue(shanghaiWSGPointer.distance(shanghaiGCJPointer.toWSGPointer()) < 5);
-    assertTrue(shanghaiWSGPointer.distance(shenzhenGCJPointer.toWSGPointer()) < 5);
-    assertTrue(shanghaiWSGPointer.distance(beijingGCJPointer.toWSGPointer()) < 5);
+  public void testGCJ2WGS() {
+    assertTrue(shanghaiWGSPointer.distance(shanghaiGCJPointer.toWGSPointer()) < 5);
+    assertTrue(shanghaiWGSPointer.distance(shenzhenGCJPointer.toWGSPointer()) < 5);
+    assertTrue(shanghaiWGSPointer.distance(beijingGCJPointer.toWGSPointer()) < 5);
   }
 
-  public void testGCJ2ExtactWSG() {
-    assertTrue(shanghaiWSGPointer.distance(shanghaiGCJPointer.toExactWSGPointer()) < 0.5);
-    assertTrue(shanghaiWSGPointer.distance(shenzhenGCJPointer.toExactWSGPointer()) < 0.5);
-    assertTrue(shanghaiWSGPointer.distance(beijingGCJPointer.toExactWSGPointer()) < 0.5);
+  public void testGCJ2ExtactWGS() {
+    assertTrue(shanghaiWGSPointer.distance(shanghaiGCJPointer.toExactWGSPointer()) < 0.5);
+    assertTrue(shanghaiWGSPointer.distance(shenzhenGCJPointer.toExactWGSPointer()) < 0.5);
+    assertTrue(shanghaiWGSPointer.distance(beijingGCJPointer.toExactWGSPointer()) < 0.5);
   }
 }


### PR DESCRIPTION
There's a typo in the Java code. WGS is the correct spelling, not WSG.