### PR TITLE
Fix JavaScript version of gcj2wgs_exact

### DIFF
--- a/javascript/test.js
+++ b/javascript/test.js
@@ -44,7 +44,7 @@ for (var i = 0; i < tests.length; i++) {
 	var wgs = transform.gcj2wgs_exact(gcjLat, gcjLng);
 	var d = transform.distance(wgs.lat, wgs.lng, tests[i][0], tests[i][1]);
 	if (d > 0.5) {
-		console.log("gcj2wgs_exact test " + i + ": distance" + d);
+		console.error("gcj2wgs_exact test " + i + ": distance" + d);
 	}
 }
 

--- a/javascript/transform.js
+++ b/javascript/transform.js
@@ -87,8 +87,8 @@ function gcj2wgs_exact(gcjLat, gcjLng) {
 		// newCoord = gcjCoord - wgs_to_gcj_delta(newCoord)
 		var tmp = wgs2gcj(newLat, newLng);
 		// approx difference using gcj-space difference
-		newLat -= gcjLat - tmp.lat;
-		newLng -= gcjLng - tmp.lng;
+		newLat += gcjLat - tmp.lat;
+		newLng += gcjLng - tmp.lng;
 		// diffchk
 		if (Math.max(Math.abs(oldLat - newLat), Math.abs(oldLng - newLng)) < threshold) {
 			break;


### PR DESCRIPTION
The test was actually failing:
% npm test        

> eviltransform@0.2.2 test /Users/chenxing/eviltransform/javascript
> node test.js

gcj2wgs_exact test 0: distance5695312.758504871
gcj2wgs_exact test 1: distance12596699.5673844
gcj2wgs_exact test 2: distance14679927.891650176
wgs2gcj	2564103	223 ns/op
gcj2wgs	3225806	213 ns/op
gcj2wgs_exact	348432	2770 ns/op
distance	9090909	11 ns/op

Now the errors are gone.